### PR TITLE
Disable ExDebugger

### DIFF
--- a/apps/ex_cucumber/lib/ex_cucumber.ex
+++ b/apps/ex_cucumber/lib/ex_cucumber.ex
@@ -4,7 +4,7 @@ defmodule ExCucumber do
   @external_resource "config/config.exs"
 
   alias CucumberExpressions.ParameterType
-  use ExDebugger.Manual
+  # use ExDebugger.Manual
 
   def file_path, do: "#{__DIR__}/ex_cucumber.ex"
 

--- a/apps/ex_cucumber/lib/ex_cucumber/config.ex
+++ b/apps/ex_cucumber/lib/ex_cucumber/config.ex
@@ -17,7 +17,7 @@ defmodule ExCucumber.Config do
   @best_practices Application.get_env(:ex_cucumber, :best_practices, %{})
 
   alias ExCucumber.Exceptions.ConfigurationError
-  use ExDebugger.Manual
+  # use ExDebugger.Manual
 
   def file_path, do: "#{__DIR__}/config.ex"
   def default_env, do: example_env(project_root: File.cwd!(), feature_dir: "features")
@@ -51,7 +51,7 @@ defmodule ExCucumber.Config do
 
   def feature_path(feature_file_name) when is_binary(feature_file_name) do
     full_feature_path = "#{feature_dir()}/#{feature_file_name}"
-    dd(:feature_path)
+    # dd(:feature_path)
 
     if File.exists?(full_feature_path) do
       full_feature_path

--- a/apps/ex_cucumber/lib/ex_cucumber/exceptions/messages/messages.ex
+++ b/apps/ex_cucumber/lib/ex_cucumber/exceptions/messages/messages.ex
@@ -1,7 +1,7 @@
 defmodule ExCucumber.Exceptions.Messages do
   @moduledoc false
 
-  use ExDebugger.Manual
+  # use ExDebugger.Manual
 
   alias __MODULE__.{
     BestPracticesIncomplete,
@@ -71,7 +71,7 @@ defmodule ExCucumber.Exceptions.Messages do
 
   def render(f, exit?) when is_atom(exit?) do
     error_detail_level = ExCucumber.Config.error_detail_level()
-    dd(:render)
+    # dd(:render)
 
     if error_detail_level == :verbose do
       {heading, body} = render(f, detail_level: :verbose)

--- a/apps/ex_cucumber/lib/ex_cucumber/gherkin/gherkin.ex
+++ b/apps/ex_cucumber/lib/ex_cucumber/gherkin/gherkin.ex
@@ -3,7 +3,7 @@ defmodule ExCucumber.Gherkin do
   alias __MODULE__.Traverser
   alias ExCucumber.Exceptions.MatchFailure
 
-  use ExDebugger.Manual
+  # use ExDebugger.Manual
 
   def run_all(path) do
     "#{path}/*.feature"
@@ -29,8 +29,9 @@ defmodule ExCucumber.Gherkin do
     |> ExGherkin.prepare()
     |> ExGherkin.run()
     |> elem(1)
-    |> dd(:raw_feature)
+    # |> dd(:raw_feature)
     |> ExGherkin.AstNdjson.run()
-    |> dd(:run)
+
+    # |> dd(:run)
   end
 end

--- a/apps/ex_cucumber/lib/ex_cucumber/gherkin/traverser/step_traverser.ex
+++ b/apps/ex_cucumber/lib/ex_cucumber/gherkin/traverser/step_traverser.ex
@@ -11,7 +11,7 @@ defmodule ExCucumber.Gherkin.Traverser.Step do
   }
 
   alias ExGherkin.AstNdjson.Step.DataTable
-  use ExDebugger.Manual
+  # use ExDebugger.Manual
 
   def run(%ExGherkin.AstNdjson.Step{} = s, acc, parse_tree) do
     [hd | _] = acc.extra.context_history
@@ -69,7 +69,8 @@ defmodule ExCucumber.Gherkin.Traverser.Step do
           keyword: ctx.keyword
         }
       })
-      |> dd(:run)
+
+    # |> dd(:run)
 
     event = %{
       feature_file: %{


### PR DESCRIPTION
* Whenever there is a major elixir version change; it tends to break.
* When it proves to be needed we can always add it back.